### PR TITLE
블로그 & 카테고리 CRUD 구현

### DIFF
--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -34,13 +35,13 @@ public class BlogController {
     private final CategoryService categoryService;
     private final MemberService memberService;
 
-    @PostMapping("/blogs/{member-id}")
+    @PostMapping("/blogs")
     public ResponseEntity postBlog(@RequestBody @Valid BlogDto.Post blogPostDto,
-                                   @PathVariable(value = "member-id", required = false) long memberId) {
+                                   @AuthenticationPrincipal Member member) {
         //TODO: Member & Comment 추가예정
-        Member member = memberService.findMember(memberId);
+        Member foundMember = memberService.findMember(member.getMemberId());
         Category category = categoryService.findSingleCategoryById(blogPostDto.getCategoryId());
-        Blog blog = mapper.blogPostDtoToBlog(blogPostDto, category, member);
+        Blog blog = mapper.blogPostDtoToBlog(blogPostDto, category, foundMember);
         blogService.createBlog(blog);
 
         return new ResponseEntity(HttpStatus.CREATED);

--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -28,14 +28,13 @@ import java.util.List;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/blogs")
 public class BlogController {
     private final BlogService blogService;
     private final BlogMapper mapper;
     private final CategoryService categoryService;
     private final MemberService memberService;
 
-    @PostMapping("{member-id}")
+    @PostMapping("/blogs/{member-id}")
     public ResponseEntity postBlog(@RequestBody @Valid BlogDto.Post blogPostDto,
                                    @PathVariable(value = "member-id", required = false) long memberId) {
         //TODO: Member & Comment 추가예정
@@ -47,7 +46,7 @@ public class BlogController {
         return new ResponseEntity(HttpStatus.CREATED);
     }
 
-    @PatchMapping("/edit/{blog-id}")
+    @PatchMapping("/blogs/edit/{blog-id}")
     public ResponseEntity patchBlog(@RequestBody @Valid BlogDto.Patch blogPatchDto,
                                     @PathVariable("blog-id") @Positive long blogId) {
         blogPatchDto.setBlogId(blogId);
@@ -58,7 +57,7 @@ public class BlogController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    @GetMapping("/{blog-id}")
+    @GetMapping("/blogs/{blog-id}")
     public ResponseEntity getBlogById(@PathVariable("blog-id") @Positive long blogId) {
         //TODO: Comment 추가 필요
         Blog blog = blogService.findBlog(blogId);
@@ -67,7 +66,7 @@ public class BlogController {
         return ResponseEntity.ok(new SingleResponseDto<>(blogResponseDto));
     }
 
-    @GetMapping("/category/{category-id}")
+    @GetMapping("/blogs/category/{category-id}")
     public ResponseEntity getBlogsByCategoryName(@PathVariable("category-id") long categoryId,
                                                  @RequestParam(required = false, defaultValue = "1") int page,
                                                  @RequestParam(required = false, defaultValue = "12") int size) {
@@ -79,7 +78,7 @@ public class BlogController {
     }
 
     // 개인 블로그 데이터 전체 게시글 조회
-    @GetMapping("/all")
+    @GetMapping("/blogs/all")
     public ResponseEntity getBlogsByNickname(@RequestParam @NotBlank String nickname,
                                              @RequestParam(required = false, defaultValue = "1") int page,
                                              @RequestParam(required = false, defaultValue = "12") int size) {
@@ -91,7 +90,7 @@ public class BlogController {
         return new ResponseEntity(new MultiResponseDto.BlogList<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
     }
 
-    @GetMapping("/edit/{blog-id}")
+    @GetMapping("/blogs/edit/{blog-id}")
     public ResponseEntity getBlog(@PathVariable("blog-id") @Positive long blogId) {
         Blog blog = blogService.findBlog(blogId);
         BlogResponseDto blogResponseDto = mapper.blogToBlogResponseDto(blog);
@@ -99,7 +98,7 @@ public class BlogController {
         return ResponseEntity.ok(new SingleResponseDto<>(blogResponseDto));
     }
 
-    @DeleteMapping("/{blog-id}")
+    @DeleteMapping("/blogs/{blog-id}")
     public ResponseEntity deleteBlog(@PathVariable("blog-id") @Positive long blogId) {
         blogService.deleteBlog(blogId);
 

--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -7,9 +7,13 @@ import com.server.domain.blog.mapper.BlogMapper;
 import com.server.domain.blog.service.BlogService;
 import com.server.domain.category.entity.Category;
 import com.server.domain.category.service.CategoryService;
+import com.server.domain.member.entity.Member;
+import com.server.domain.member.service.MemberService;
+import com.server.response.MultiResponseDto;
 import com.server.response.SingleResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -17,6 +21,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.util.List;
 
 @Slf4j
 @Validated
@@ -27,12 +32,15 @@ public class BlogController {
     private final BlogService blogService;
     private final BlogMapper mapper;
     private final CategoryService categoryService;
+    private final MemberService memberService;
 
-    @PostMapping
-    public ResponseEntity postBlog(@RequestBody @Valid BlogDto.Post blogPostDto) {
+    @PostMapping("{member-id}")
+    public ResponseEntity postBlog(@RequestBody @Valid BlogDto.Post blogPostDto,
+                                   @PathVariable(value = "member-id", required = false) long memberId) {
         //TODO: Member & Comment 추가예정
-        Category singleCategory = categoryService.findSingleCategory(blogPostDto.getCategoryId());
-        Blog blog = mapper.blogPostDtoToBlog(blogPostDto, singleCategory);
+        Member member = memberService.findMember(memberId);
+        Category category = categoryService.findSingleCategoryByName(blogPostDto.getCategoryName());
+        Blog blog = mapper.blogPostDtoToBlog(blogPostDto, category, member);
         blogService.createBlog(blog);
 
         return new ResponseEntity(HttpStatus.CREATED);
@@ -42,15 +50,47 @@ public class BlogController {
     public ResponseEntity patchBlog(@RequestBody @Valid BlogDto.Patch blogPatchDto,
                                     @PathVariable("blog-id") @Positive long blogId) {
         blogPatchDto.setBlogId(blogId);
-        Category singleCategory = categoryService.findSingleCategory(blogPatchDto.getCategoryId());
+        Category singleCategory = categoryService.findSingleCategoryByName(blogPatchDto.getCategoryName());
         Blog blog = mapper.blogPatchDtoToBlog(blogPatchDto, singleCategory);
         blogService.editBlog(blog);
 
         return new ResponseEntity(HttpStatus.OK);
     }
 
+    @GetMapping("/{blog-id}")
+    public ResponseEntity getBlogById(@PathVariable("blog-id") @Positive long blogId) {
+        //TODO: Comment 추가 필요
+        Blog blog = blogService.findBlog(blogId);
+        BlogResponseDto blogResponseDto = mapper.blogToBlogResponseDto(blog);
+
+        return ResponseEntity.ok(new SingleResponseDto<>(blogResponseDto));
+    }
+
+    @GetMapping("{category-name}")
+    public ResponseEntity getBlogsByCategoryName(@PathVariable("category-name") String categoryName,
+                                                 @RequestParam(required = false, defaultValue = "1") int page,
+                                                 @RequestParam(required = false, defaultValue = "12") int size) {
+        Page<Blog> blogsPageInfo = blogService.findBlogsByCategoryName(categoryName, page, size);
+        List<Blog> blogs = blogsPageInfo.getContent();
+        List<BlogResponseDto.WithCategory> blogResponseDtoWithCategory = mapper.blogListToBlogResponseDtoWithCategory(blogs);
+
+        return new ResponseEntity(new MultiResponseDto<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
+    }
+
+    @GetMapping("{nickname}")
+    public ResponseEntity getBlogsByNickname(@PathVariable("nickname") String nickname,
+                                           @RequestParam(required = false, defaultValue = "1") int page,
+                                           @RequestParam(required = false, defaultValue = "12") int size) {
+
+        Page<Blog> blogsPageInfo = blogService.findBlogsByMemberNickname(nickname, page, size);
+        List<Blog> blogs = blogsPageInfo.getContent();
+        List<BlogResponseDto.WithCategory> blogResponseDtoWithCategory = mapper.blogListToBlogResponseDtoWithCategory(blogs);
+
+        return new ResponseEntity(new MultiResponseDto<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
+    }
+
     @GetMapping("/edit/{blog-id}")
-    public ResponseEntity getPost(@PathVariable("blog-id") @Positive long blogId) {
+    public ResponseEntity getBlog(@PathVariable("blog-id") @Positive long blogId) {
         Blog blog = blogService.findBlog(blogId);
         BlogResponseDto blogResponseDto = mapper.blogToBlogResponseDto(blog);
 
@@ -58,7 +98,7 @@ public class BlogController {
     }
 
     @DeleteMapping("{blog-id}")
-    public ResponseEntity deletePost(@PathVariable("blog-id") @Positive long blogId) {
+    public ResponseEntity deleteBlog(@PathVariable("blog-id") @Positive long blogId) {
         blogService.deleteBlog(blogId);
 
         return new ResponseEntity(HttpStatus.NO_CONTENT);

--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -20,6 +20,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class BlogController {
                                    @PathVariable(value = "member-id", required = false) long memberId) {
         //TODO: Member & Comment 추가예정
         Member member = memberService.findMember(memberId);
-        Category category = categoryService.findSingleCategoryByName(blogPostDto.getCategoryName());
+        Category category = categoryService.findSingleCategoryById(blogPostDto.getCategoryId());
         Blog blog = mapper.blogPostDtoToBlog(blogPostDto, category, member);
         blogService.createBlog(blog);
 
@@ -66,27 +67,28 @@ public class BlogController {
         return ResponseEntity.ok(new SingleResponseDto<>(blogResponseDto));
     }
 
-    @GetMapping("{category-name}")
-    public ResponseEntity getBlogsByCategoryName(@PathVariable("category-name") String categoryName,
+    @GetMapping("/category/{category-id}")
+    public ResponseEntity getBlogsByCategoryName(@PathVariable("category-id") long categoryId,
                                                  @RequestParam(required = false, defaultValue = "1") int page,
                                                  @RequestParam(required = false, defaultValue = "12") int size) {
-        Page<Blog> blogsPageInfo = blogService.findBlogsByCategoryName(categoryName, page, size);
+        Page<Blog> blogsPageInfo = blogService.findBlogsByCategoryId(categoryId, page, size);
         List<Blog> blogs = blogsPageInfo.getContent();
         List<BlogResponseDto.WithCategory> blogResponseDtoWithCategory = mapper.blogListToBlogResponseDtoWithCategory(blogs);
 
-        return new ResponseEntity(new MultiResponseDto<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
+        return new ResponseEntity(new MultiResponseDto.BlogList<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
     }
 
-    @GetMapping("{nickname}")
-    public ResponseEntity getBlogsByNickname(@PathVariable("nickname") String nickname,
-                                           @RequestParam(required = false, defaultValue = "1") int page,
-                                           @RequestParam(required = false, defaultValue = "12") int size) {
+    // 개인 블로그 데이터 전체 게시글 조회
+    @GetMapping("/all")
+    public ResponseEntity getBlogsByNickname(@RequestParam @NotBlank String nickname,
+                                             @RequestParam(required = false, defaultValue = "1") int page,
+                                             @RequestParam(required = false, defaultValue = "12") int size) {
 
         Page<Blog> blogsPageInfo = blogService.findBlogsByMemberNickname(nickname, page, size);
         List<Blog> blogs = blogsPageInfo.getContent();
         List<BlogResponseDto.WithCategory> blogResponseDtoWithCategory = mapper.blogListToBlogResponseDtoWithCategory(blogs);
 
-        return new ResponseEntity(new MultiResponseDto<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
+        return new ResponseEntity(new MultiResponseDto.BlogList<>(blogResponseDtoWithCategory, blogsPageInfo), HttpStatus.OK);
     }
 
     @GetMapping("/edit/{blog-id}")
@@ -97,7 +99,7 @@ public class BlogController {
         return ResponseEntity.ok(new SingleResponseDto<>(blogResponseDto));
     }
 
-    @DeleteMapping("{blog-id}")
+    @DeleteMapping("/{blog-id}")
     public ResponseEntity deleteBlog(@PathVariable("blog-id") @Positive long blogId) {
         blogService.deleteBlog(blogId);
 

--- a/server/src/main/java/com/server/domain/blog/dto/BlogDto.java
+++ b/server/src/main/java/com/server/domain/blog/dto/BlogDto.java
@@ -16,7 +16,7 @@ public class BlogDto {
         private String titleImageUrl;
         private String blogTitle;
         private String blogContent;
-        private String categoryName;
+        private long categoryId;
     }
 
     @Getter

--- a/server/src/main/java/com/server/domain/blog/dto/BlogDto.java
+++ b/server/src/main/java/com/server/domain/blog/dto/BlogDto.java
@@ -16,9 +16,7 @@ public class BlogDto {
         private String titleImageUrl;
         private String blogTitle;
         private String blogContent;
-        @Setter
-        @NotNull
-        private Long categoryId;
+        private String categoryName;
     }
 
     @Getter
@@ -28,7 +26,6 @@ public class BlogDto {
         private String titleImageUrl;
         private String blogTitle;
         private String blogContent;
-        @NotNull
-        private Long categoryId;
+        private String categoryName;
     }
 }

--- a/server/src/main/java/com/server/domain/blog/dto/BlogResponseDto.java
+++ b/server/src/main/java/com/server/domain/blog/dto/BlogResponseDto.java
@@ -1,17 +1,37 @@
 package com.server.domain.blog.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.server.domain.comment.entity.Comment;
+import lombok.Builder;
 import lombok.Data;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
-import javax.persistence.Column;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
+@Builder
 public class BlogResponseDto {
-    private String titleImageUrl;
+
     private String blogTitle;
     private String blogContent;
-    private long categoryId;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+    private String categoryName;
+
+//    private List<Comment> commentList;
+
+    @Builder
+    @Data
+    public static class WithCategory {
+        private long blogId;
+        private String titleImageUrl;
+        private String blogTitle;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+        private LocalDateTime createdAt;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
+        private LocalDateTime modifiedAt;
+//        private int commentCount;
+//        private int likeCount;
+    }
 
 }

--- a/server/src/main/java/com/server/domain/blog/dto/BlogResponseDto.java
+++ b/server/src/main/java/com/server/domain/blog/dto/BlogResponseDto.java
@@ -12,11 +12,12 @@ import java.util.List;
 @Builder
 public class BlogResponseDto {
 
+    private String titleImageUrl;
     private String blogTitle;
     private String blogContent;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
-    private String categoryName;
+    private Long categoryId;
 
 //    private List<Comment> commentList;
 

--- a/server/src/main/java/com/server/domain/blog/entity/Blog.java
+++ b/server/src/main/java/com/server/domain/blog/entity/Blog.java
@@ -6,6 +6,7 @@ import com.server.domain.member.entity.Member;
 import lombok.*;
 import lombok.extern.jbosslog.JBossLog;
 import org.springframework.stereotype.Service;
+import reactor.util.annotation.Nullable;
 
 import javax.persistence.*;
 
@@ -30,9 +31,9 @@ public class Blog extends Auditable {
     @Column(name = "title_image_url")
     private String titleImageUrl;
 
-//    @ManyToOne
-//    @JoinColumn(name = "member_id")
-//    private Member member;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
 
     @ManyToOne
     @JoinColumn(name = "category_id")

--- a/server/src/main/java/com/server/domain/blog/mapper/BlogMapper.java
+++ b/server/src/main/java/com/server/domain/blog/mapper/BlogMapper.java
@@ -5,15 +5,20 @@ import com.server.domain.blog.dto.BlogDto;
 import com.server.domain.blog.dto.BlogResponseDto;
 import com.server.domain.blog.entity.Blog;
 import com.server.domain.category.entity.Category;
+import com.server.domain.member.entity.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
+import java.util.List;
+import java.util.Optional;
+
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface BlogMapper {
-    Blog blogPostDtoToBlog(BlogDto.Post blogPostDto, Category category);
+    Blog blogPostDtoToBlog(BlogDto.Post blogPostDto, Category category, Member member);
     Blog blogPatchDtoToBlog(BlogDto.Patch blogPatchDto, Category category);
-
-    @Mapping(target = "categoryId", expression = "java(blog.getCategory().getCategoryId())")
+//    @Mapping(target = "categoryId", expression = "java(blog.getCategory().getCategoryId())")
+    @Mapping(target = "categoryName", expression = "java(blog.getCategory().getCategoryName())")
     BlogResponseDto blogToBlogResponseDto(Blog blog);
+    List<BlogResponseDto.WithCategory> blogListToBlogResponseDtoWithCategory(List<Blog> blogs);
 }

--- a/server/src/main/java/com/server/domain/blog/mapper/BlogMapper.java
+++ b/server/src/main/java/com/server/domain/blog/mapper/BlogMapper.java
@@ -11,7 +11,6 @@ import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 
 import java.util.List;
-import java.util.Optional;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface BlogMapper {
@@ -20,7 +19,7 @@ public interface BlogMapper {
     @Mapping(target = "category", source = "category")
     Blog blogPatchDtoToBlog(BlogDto.Patch blogPatchDto, Category category);
 //    @Mapping(target = "categoryId", expression = "java(blog.getCategory().getCategoryId())")
-    @Mapping(target = "categoryName", expression = "java(blog.getCategory().getCategoryName())")
+    @Mapping(target = "categoryId", expression = "java(blog.getCategory().getCategoryId())")
     BlogResponseDto blogToBlogResponseDto(Blog blog);
     List<BlogResponseDto.WithCategory> blogListToBlogResponseDtoWithCategory(List<Blog> blogs);
 }

--- a/server/src/main/java/com/server/domain/blog/mapper/BlogMapper.java
+++ b/server/src/main/java/com/server/domain/blog/mapper/BlogMapper.java
@@ -15,7 +15,9 @@ import java.util.Optional;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface BlogMapper {
+    @Mapping(target = "category", source = "category")
     Blog blogPostDtoToBlog(BlogDto.Post blogPostDto, Category category, Member member);
+    @Mapping(target = "category", source = "category")
     Blog blogPatchDtoToBlog(BlogDto.Patch blogPatchDto, Category category);
 //    @Mapping(target = "categoryId", expression = "java(blog.getCategory().getCategoryId())")
     @Mapping(target = "categoryName", expression = "java(blog.getCategory().getCategoryName())")

--- a/server/src/main/java/com/server/domain/blog/repository/BlogRepository.java
+++ b/server/src/main/java/com/server/domain/blog/repository/BlogRepository.java
@@ -1,7 +1,17 @@
 package com.server.domain.blog.repository;
 
 import com.server.domain.blog.entity.Blog;
+import com.server.domain.category.entity.Category;
+import com.server.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BlogRepository extends JpaRepository<Blog, Long> {
+
+    Page<Blog> findAllByCategory(Category category, Pageable pageable);
+    Page<Blog> findAllByMember(Member member, Pageable pageable);
+
+
 }

--- a/server/src/main/java/com/server/domain/blog/service/BlogService.java
+++ b/server/src/main/java/com/server/domain/blog/service/BlogService.java
@@ -51,6 +51,15 @@ public class BlogService {
         return blogs;
     }
 
+    public Page<Blog> findBlogsByCategoryId(long categoryId, int page, int size) {
+        Category singleCategory = categoryService.findSingleCategoryById(categoryId);
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("blogId").descending());
+        Page<Blog> blogs = blogRepository.findAllByCategory(singleCategory, pageable);
+
+        return blogs;
+    }
+
+
     public Page<Blog> findBlogsByMemberNickname(String nickname, int page, int size) {
         Member member = memberService.findMember(nickname);
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("blogId").descending());

--- a/server/src/main/java/com/server/domain/blog/service/BlogService.java
+++ b/server/src/main/java/com/server/domain/blog/service/BlogService.java
@@ -3,12 +3,21 @@ package com.server.domain.blog.service;
 import com.server.domain.blog.dto.BlogResponseDto;
 import com.server.domain.blog.entity.Blog;
 import com.server.domain.blog.repository.BlogRepository;
+import com.server.domain.category.entity.Category;
+import com.server.domain.category.service.CategoryService;
+import com.server.domain.member.entity.Member;
+import com.server.domain.member.service.MemberService;
 import com.server.exception.BusinessLogicException;
 import com.server.exception.ExceptionCode;
 import com.server.utils.CustomBeanUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -16,6 +25,8 @@ import java.util.Optional;
 public class BlogService {
     private final BlogRepository blogRepository;
     private final CustomBeanUtils beanUtils;
+    private final CategoryService categoryService;
+    private final MemberService memberService;
 
     public void createBlog(Blog blog) {
         blogRepository.save(blog);
@@ -30,6 +41,22 @@ public class BlogService {
 
     public Blog findBlog(long blogId) {
         return verifyBlogId(blogId);
+    }
+
+    public Page<Blog> findBlogsByCategoryName(String categoryName, int page, int size) {
+        Category singleCategory = categoryService.findSingleCategoryByName(categoryName);
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("blogId").descending());
+        Page<Blog> blogs = blogRepository.findAllByCategory(singleCategory, pageable);
+
+        return blogs;
+    }
+
+    public Page<Blog> findBlogsByMemberNickname(String nickname, int page, int size) {
+        Member member = memberService.findMember(nickname);
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("blogId").descending());
+        Page<Blog> blogs = blogRepository.findAllByMember(member, pageable);
+
+        return blogs;
     }
 
     public void deleteBlog(long blogId) {

--- a/server/src/main/java/com/server/domain/category/controller/CategoryController.java
+++ b/server/src/main/java/com/server/domain/category/controller/CategoryController.java
@@ -26,13 +26,12 @@ import java.util.List;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/category")
 public class CategoryController {
     private final CategoryService categoryService;
     private final CategoryMapper mapper;
     private final MemberService memberService;
 
-    @PostMapping({"/{member-id}"})
+    @PostMapping({"/category/{member-id}"})
     public ResponseEntity<HttpStatus> postSingleCategory(@RequestBody @Valid CategoryDto.Post categoryDtoPost,
                                                          @PathVariable("member-id") @Positive Long memberId) {
         // TODO: memberId
@@ -43,7 +42,7 @@ public class CategoryController {
         return new ResponseEntity(HttpStatus.CREATED);
     }
 
-    @PatchMapping("/{category-id}")
+    @PatchMapping("/category/{category-id}")
     public ResponseEntity<HttpStatus> patchSingleCategory(@RequestBody CategoryDto.Patch categoryDtoPatch,
                                                           @PathVariable("category-id") @Min(value = 2) long categoryId) {
         categoryDtoPatch.setCategoryId(categoryId);
@@ -53,7 +52,7 @@ public class CategoryController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    @GetMapping()
+    @GetMapping("/category")
     public ResponseEntity<MultiResponseDto> getAllCategories(@RequestParam(required = false, defaultValue = "1") int page,
                                                               @RequestParam(required = false, defaultValue = "12") int size) {
         Page<Category> categoryPageInfo = categoryService.findAllCategories(page, size);
@@ -63,7 +62,7 @@ public class CategoryController {
         return new ResponseEntity(new MultiResponseDto.CategoryList<>(categoryResponseDtos, categoryPageInfo), HttpStatus.OK);
     }
 
-    @GetMapping("/{member-id}")
+    @GetMapping("/category/{member-id}")
     public ResponseEntity<SingleResponseDto.Category> getAllCategoriesEachMember(@PathVariable("member-id") @Positive long memberId) {
         List<Category> allCategoriesEachMember = categoryService.findAllCategoriesEachMember(memberId);
         List<CategoryResponseDto> categoryResponseDtos = mapper.categoriesToCategoryResponseDto(allCategoriesEachMember);
@@ -71,7 +70,7 @@ public class CategoryController {
         return ResponseEntity.ok(new SingleResponseDto.Category(categoryResponseDtos));
     }
 
-    @DeleteMapping("/{category-id}")
+    @DeleteMapping("/category/{category-id}")
     public ResponseEntity<HttpStatus> deleteSingleCategory(@PathVariable("category-id") @Min(value = 2) long categoryId) {
         categoryService.deleteSingleCategory(categoryId);
 

--- a/server/src/main/java/com/server/domain/category/controller/CategoryController.java
+++ b/server/src/main/java/com/server/domain/category/controller/CategoryController.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,12 +32,11 @@ public class CategoryController {
     private final CategoryMapper mapper;
     private final MemberService memberService;
 
-    @PostMapping({"/category/{member-id}"})
+    @PostMapping("/category")
     public ResponseEntity<HttpStatus> postSingleCategory(@RequestBody @Valid CategoryDto.Post categoryDtoPost,
-                                                         @PathVariable("member-id") @Positive Long memberId) {
-        // TODO: memberId
-        Member member = memberService.findMember(memberId);
-        Category category = mapper.categoryDtoPostToCategory(categoryDtoPost, member);
+                                                         @AuthenticationPrincipal Member member) {
+        Member foundMember = memberService.findMember(member.getMemberId());
+        Category category = mapper.categoryDtoPostToCategory(categoryDtoPost, foundMember);
         categoryService.makeSingleCategory(category);
 
         return new ResponseEntity(HttpStatus.CREATED);
@@ -54,7 +54,7 @@ public class CategoryController {
 
     @GetMapping("/category")
     public ResponseEntity<MultiResponseDto> getAllCategories(@RequestParam(required = false, defaultValue = "1") int page,
-                                                              @RequestParam(required = false, defaultValue = "12") int size) {
+                                                             @RequestParam(required = false, defaultValue = "12") int size) {
         Page<Category> categoryPageInfo = categoryService.findAllCategories(page, size);
         List<Category> categories = categoryPageInfo.getContent();
         List<CategoryResponseDto> categoryResponseDtos = mapper.categoriesToCategoryResponseDto(categories);

--- a/server/src/main/java/com/server/domain/category/dto/CategoryResponseDto.java
+++ b/server/src/main/java/com/server/domain/category/dto/CategoryResponseDto.java
@@ -1,8 +1,11 @@
 package com.server.domain.category.dto;
 
+import com.server.domain.blog.dto.BlogResponseDto;
 import com.server.domain.blog.entity.Blog;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.util.List;
 
@@ -11,5 +14,11 @@ import java.util.List;
 public class CategoryResponseDto {
     private Long categoryId;
     private String categoryName;
-    private List<Blog> blogList;
+
+    @Data
+    @Builder
+    public static class Single {
+        private List<BlogResponseDto.WithCategory> blogList;
+    }
+
 }

--- a/server/src/main/java/com/server/domain/category/entity/Category.java
+++ b/server/src/main/java/com/server/domain/category/entity/Category.java
@@ -3,6 +3,7 @@ package com.server.domain.category.entity;
 
 import com.server.domain.audit.Auditable;
 import com.server.domain.blog.entity.Blog;
+import com.server.domain.member.entity.Member;
 import lombok.*;
 
 import javax.persistence.*;
@@ -13,14 +14,25 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Category extends Auditable {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long categoryId;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long categoryId;
 
-    @Column(name = "category_name")
-    private String categoryName;
+	@Column(name = "category_name")
+	private String categoryName;
 
-    @OneToMany(mappedBy = "category")
-    private List<Blog> blogList;
+	@OneToMany(mappedBy = "category")
+	private List<Blog> blogList;
+
+	@ManyToOne
+	@JoinColumn(name = "memberId")
+	private Member member;
+
+	@Builder
+	public Category(Long categoryId, String categoryName, Member member) {
+		this.categoryId = categoryId;
+		this.categoryName = categoryName;
+		this.member = member;
+	}
 
 }

--- a/server/src/main/java/com/server/domain/category/mapper/CategoryMapper.java
+++ b/server/src/main/java/com/server/domain/category/mapper/CategoryMapper.java
@@ -1,23 +1,36 @@
 package com.server.domain.category.mapper;
 
 
+import com.server.domain.blog.dto.BlogResponseDto;
+import com.server.domain.blog.entity.Blog;
 import com.server.domain.category.dto.CategoryDto;
 import com.server.domain.category.dto.CategoryResponseDto;
 import com.server.domain.category.entity.Category;
+import com.server.domain.member.entity.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface CategoryMapper {
-    Category categoryDtoPostToCategory(CategoryDto.Post categoryDtoPost);
+    Category categoryDtoPostToCategory(CategoryDto.Post categoryDtoPost, Member member);
 
     Category categoryDtoPatchToCategory(CategoryDto.Patch categoryDtoPatch);
-
-    default CategoryResponseDto categoryToCategoryResponseDto(Category category) {
-        return CategoryResponseDto.builder()
-                .categoryName(category.getCategoryName())
-                .categoryId(category.getCategoryId())
-                .blogList(category.getBlogList())
+    List<CategoryResponseDto> categoryToCategoryResponseDto(List<Category> categories);
+    default CategoryResponseDto.Single categoryToCategorySingleResponseDto(List<Blog> blogs) {
+        return CategoryResponseDto.Single.builder()
+                .blogList(blogs.stream().map(blog -> {
+                    return BlogResponseDto.WithCategory.builder()
+                            .blogId(blog.getBlogId())
+                            .titleImageUrl(blog.getTitleImageUrl())
+                            .blogTitle(blog.getBlogTitle())
+                            .createdAt(blog.getCreatedAt())
+                            .modifiedAt(blog.getModifiedAt())
+                            .build();
+                }).collect(Collectors.toList()))
                 .build();
     }
 }

--- a/server/src/main/java/com/server/domain/category/mapper/CategoryMapper.java
+++ b/server/src/main/java/com/server/domain/category/mapper/CategoryMapper.java
@@ -9,7 +9,6 @@ import com.server.domain.category.entity.Category;
 import com.server.domain.member.entity.Member;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;
-import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,7 +18,7 @@ public interface CategoryMapper {
     Category categoryDtoPostToCategory(CategoryDto.Post categoryDtoPost, Member member);
 
     Category categoryDtoPatchToCategory(CategoryDto.Patch categoryDtoPatch);
-    List<CategoryResponseDto> categoryToCategoryResponseDto(List<Category> categories);
+    List<CategoryResponseDto> categoriesToCategoryResponseDto(List<Category> categories);
     default CategoryResponseDto.Single categoryToCategorySingleResponseDto(List<Blog> blogs) {
         return CategoryResponseDto.Single.builder()
                 .blogList(blogs.stream().map(blog -> {

--- a/server/src/main/java/com/server/domain/category/repository/CategoryRepository.java
+++ b/server/src/main/java/com/server/domain/category/repository/CategoryRepository.java
@@ -1,15 +1,18 @@
 package com.server.domain.category.repository;
 
 
-import com.server.domain.blog.entity.Blog;
 import com.server.domain.category.entity.Category;
+import com.server.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import javax.validation.constraints.Positive;
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByCategoryName(String categoryName);
-    Page<Blog> findAllByCategoryId(long categoryId, Pageable pageable);
+    List<Category> findAllByMember(Member member);
+    Page<Category> findAll(Pageable pageable);
 }

--- a/server/src/main/java/com/server/domain/category/repository/CategoryRepository.java
+++ b/server/src/main/java/com/server/domain/category/repository/CategoryRepository.java
@@ -1,11 +1,15 @@
 package com.server.domain.category.repository;
 
 
+import com.server.domain.blog.entity.Blog;
 import com.server.domain.category.entity.Category;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByCategoryName(String categoryName);
+    Page<Blog> findAllByCategoryId(long categoryId, Pageable pageable);
 }

--- a/server/src/main/java/com/server/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/server/domain/category/service/CategoryService.java
@@ -1,9 +1,8 @@
 package com.server.domain.category.service;
 
-import com.fasterxml.jackson.databind.util.BeanUtil;
-import com.server.domain.blog.entity.Blog;
 import com.server.domain.category.entity.Category;
 import com.server.domain.category.repository.CategoryRepository;
+import com.server.domain.member.service.MemberService;
 import com.server.exception.BusinessLogicException;
 import com.server.exception.ExceptionCode;
 import com.server.utils.CustomBeanUtils;
@@ -14,7 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.security.cert.CertificateEncodingException;
+import javax.validation.constraints.Positive;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,6 +24,8 @@ public class CategoryService {
     private final CategoryRepository categoryRepository;
 
     private final CustomBeanUtils beanUtils;
+
+    private final MemberService memberService;
 
     public void makeSingleCategory(Category category) {
         verifyCategoryNameExistence(category);
@@ -54,8 +55,14 @@ public class CategoryService {
         return verifyCategoryByName(categoryName);
     }
 
-    public List<Category> findAllCategories() {
-        return categoryRepository.findAll();
+    public List<Category> findAllCategoriesEachMember(@Positive long memberId) {
+        return categoryRepository.findAllByMember(memberService.findMember(memberId));
+    }
+
+    public Page<Category> findAllCategories(int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size);
+
+        return categoryRepository.findAll(pageable);
     }
 
     public void deleteSingleCategory(long categoryId) {

--- a/server/src/main/java/com/server/domain/category/service/CategoryService.java
+++ b/server/src/main/java/com/server/domain/category/service/CategoryService.java
@@ -1,6 +1,7 @@
 package com.server.domain.category.service;
 
 import com.fasterxml.jackson.databind.util.BeanUtil;
+import com.server.domain.blog.entity.Blog;
 import com.server.domain.category.entity.Category;
 import com.server.domain.category.repository.CategoryRepository;
 import com.server.exception.BusinessLogicException;
@@ -8,8 +9,13 @@ import com.server.exception.ExceptionCode;
 import com.server.utils.CustomBeanUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.security.cert.CertificateEncodingException;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -34,14 +40,22 @@ public class CategoryService {
     }
 
     public void editSingleCategory(Category category) {
-        Category singleCategory = findSingleCategory(category.getCategoryId());
+        Category singleCategory = findSingleCategoryById(category.getCategoryId());
         beanUtils.copyNonNullProperties(category, singleCategory);
 
         categoryRepository.save(singleCategory);
     }
 
-    public Category findSingleCategory(long categoryId) {
+    public Category findSingleCategoryById(long categoryId) {
         return verifyCategoryById(categoryId);
+    }
+
+    public Category findSingleCategoryByName(String categoryName) {
+        return verifyCategoryByName(categoryName);
+    }
+
+    public List<Category> findAllCategories() {
+        return categoryRepository.findAll();
     }
 
     public void deleteSingleCategory(long categoryId) {
@@ -53,4 +67,10 @@ public class CategoryService {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND));
     }
+
+    private Category verifyCategoryByName(String categoryName) {
+        return categoryRepository.findByCategoryName(categoryName)
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.CATEGORY_NOT_FOUND));
+    }
+
 }

--- a/server/src/main/java/com/server/domain/member/controller/MemberController.java
+++ b/server/src/main/java/com/server/domain/member/controller/MemberController.java
@@ -33,6 +33,7 @@ public class MemberController {
     public ResponseEntity signupMember(@Valid @RequestBody MemberDto.Post memberPostDto) {
         // memberservice에 회원 생성 로직 타게 만들기
         Member member = memberService.createMember(mapper.memberPostDtoToMember(memberPostDto));
+
         // 반환 값 -> url, http code 201
         URI location = UriComponentsBuilder.newInstance()
                 .path("/members/{member-id}")

--- a/server/src/main/java/com/server/domain/member/dto/MemberDto.java
+++ b/server/src/main/java/com/server/domain/member/dto/MemberDto.java
@@ -1,6 +1,5 @@
 package com.server.domain.member.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/server/src/main/java/com/server/domain/member/entity/Member.java
+++ b/server/src/main/java/com/server/domain/member/entity/Member.java
@@ -2,6 +2,7 @@ package com.server.domain.member.entity;
 
 import com.server.domain.audit.Auditable;
 import com.server.domain.blog.entity.Blog;
+import com.server.domain.category.entity.Category;
 import com.server.domain.imageFile.entity.ImageFile;
 import lombok.*;
 
@@ -48,5 +49,8 @@ public class Member extends Auditable {
 //    @OneToOne
 //    @JoinColumn(name = "image_file_id")
 //    private ImageFile imageFile;
+
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private List<Category> categories;
 
 }

--- a/server/src/main/java/com/server/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/server/domain/member/service/MemberService.java
@@ -1,22 +1,33 @@
 package com.server.domain.member.service;
 
+import com.server.domain.category.entity.Category;
+import com.server.domain.category.repository.CategoryRepository;
+import com.server.domain.category.service.CategoryService;
 import com.server.domain.member.entity.Member;
 import com.server.domain.member.repository.MemberRepository;
 import com.server.exception.BusinessLogicException;
 import com.server.exception.ExceptionCode;
 import com.server.security.utils.MemberAuthorityUtils;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
     private final MemberRepository memberRepository;
     private final MemberAuthorityUtils authorityUtils;
     private final PasswordEncoder passwordEncoder;
+
+    private final CategoryRepository categoryRepository;
 
     // 회원 생성
     public Member createMember(Member member) {
@@ -27,10 +38,24 @@ public class MemberService {
         member.setPassword(encryptedPassword);
         member.setRoles(authorityUtils.createRole());
 
+
         Member saveMember = memberRepository.save(member);
+
+        //category 더미 추가
+        List<Category> categoryList = new ArrayList<>();
+        Category category = Category.builder()
+                .categoryId(1L)
+                .categoryName("없음")
+                .member(saveMember)
+                .build();
+
+        categoryList.add(category);
+        categoryRepository.save(category);
+        member.setCategories(categoryList);
 
         return saveMember;
     }
+
     // 회원 정보 수정
     public Member updateMember(long memberId, Member member) {
         Member findMember = findVerifiedMember(memberId);
@@ -42,26 +67,46 @@ public class MemberService {
 
         return memberRepository.save(findMember);
     }
+
     // 회원 정보 가져오기
     public Member findMember(long memberId) {
         Member findMember = findVerifiedMember(memberId);
         return findMember;
     }
 
+    public Member findMember(String nickname) {
+        Member findMember = findVerifiedMember(nickname);
+        return findMember;
+    }
+
+    private Member findVerifiedMember(String nickname) {
+        Optional<Member> optionalMember =
+                memberRepository.findByNickName(nickname);
+
+        Member findMember =
+                optionalMember.orElseThrow(
+                        () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)
+                );
+
+        return findMember;
+    }
+
+
     // 닉네임 중복 확인
     public void verifyExistNickName(String nickName) {
         Optional<Member> optionalMember =
                 memberRepository.findByNickName(nickName);
 
-        if(optionalMember.isPresent()){
+        if (optionalMember.isPresent()) {
             throw new BusinessLogicException(ExceptionCode.MEMBER_EXISTS);
         }
     }
-    public void verifyExistEmail(String email){
+
+    public void verifyExistEmail(String email) {
         Optional<Member> optionalMember =
                 memberRepository.findByEmail(email);
 
-        if(optionalMember.isPresent()){
+        if (optionalMember.isPresent()) {
             throw new BusinessLogicException(ExceptionCode.MEMBER_EXISTS);
         }
     }
@@ -72,7 +117,7 @@ public class MemberService {
 
         Member findMember =
                 optionalMember.orElseThrow(
-                        ()-> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)
+                        () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND)
                 );
 
         return findMember;

--- a/server/src/main/java/com/server/domain/member/service/MemberService.java
+++ b/server/src/main/java/com/server/domain/member/service/MemberService.java
@@ -44,7 +44,6 @@ public class MemberService {
         //category 더미 추가
         List<Category> categoryList = new ArrayList<>();
         Category category = Category.builder()
-                .categoryId(1L)
                 .categoryName("없음")
                 .member(saveMember)
                 .build();

--- a/server/src/main/java/com/server/response/MultiResponseDto.java
+++ b/server/src/main/java/com/server/response/MultiResponseDto.java
@@ -1,13 +1,18 @@
 package com.server.response;
 
-import lombok.AllArgsConstructor;
+import com.server.response.PageInfo;
 import lombok.Getter;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 @Getter
-@AllArgsConstructor
 public class MultiResponseDto<T> {
     private List<T> data;
     private PageInfo pageInfo;
+
+    public MultiResponseDto(List<T> data, Page page) {
+        this.data = data;
+        this.pageInfo = new PageInfo(page.getNumber() + 1, page.getSize(), page.getTotalElements(), page.getTotalPages());
+    }
 }

--- a/server/src/main/java/com/server/response/MultiResponseDto.java
+++ b/server/src/main/java/com/server/response/MultiResponseDto.java
@@ -1,6 +1,5 @@
 package com.server.response;
 
-import com.server.response.PageInfo;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
@@ -15,4 +14,26 @@ public class MultiResponseDto<T> {
         this.data = data;
         this.pageInfo = new PageInfo(page.getNumber() + 1, page.getSize(), page.getTotalElements(), page.getTotalPages());
     }
+    @Getter
+    public static class BlogList<T> {
+        private List<T> blogList;
+        private PageInfo pageInfo;
+
+        public BlogList(List<T> data, Page page) {
+            this.blogList = data;
+            this.pageInfo = new PageInfo(page.getNumber() + 1, page.getSize(), page.getTotalElements(), page.getTotalPages());
+        }
+    }
+
+    @Getter
+    public static class CategoryList<T> {
+        private List<T> categoryList;
+        private PageInfo pageInfo;
+
+        public CategoryList(List<T> data, Page page) {
+            this.categoryList = data;
+            this.pageInfo = new PageInfo(page.getNumber() + 1, page.getSize(), page.getTotalElements(), page.getTotalPages());
+        }
+    }
+
 }

--- a/server/src/main/java/com/server/response/PageInfo.java
+++ b/server/src/main/java/com/server/response/PageInfo.java
@@ -1,20 +1,14 @@
 package com.server.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
+@AllArgsConstructor
 public class PageInfo {
     private int page;
     private int size;
-    private int totalElements;
+    private long totalElements;
     private int totalPages;
-
-    public PageInfo(int page, int size, int totalElements, int totalPages) {
-        this.page = page;
-        this.size = size;
-        this.totalElements = totalElements;
-        this.totalPages = totalPages;
-    }
 }

--- a/server/src/main/java/com/server/response/SingleResponseDto.java
+++ b/server/src/main/java/com/server/response/SingleResponseDto.java
@@ -7,4 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class SingleResponseDto<T> {
     private T data;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Category<T> {
+        private T categoryList;
+    }
 }

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -11,10 +11,10 @@ spring:
       path: /h2
   datasource:
     url: jdbc:h2:mem:test
-  sql:
-    init:
-      mode: always
-      data-locations: classpath*:db/h2/data.sql
+#  sql:
+#    init:
+#      mode: always
+#      data-locations: classpath*:db/h2/data.sql
 
   jpa:
     hibernate:

--- a/server/src/main/resources/db/h2/data.sql
+++ b/server/src/main/resources/db/h2/data.sql
@@ -1,1 +1,1 @@
-INSERT INTO category(created_At, modified_At, category_name) VALUES ('2023-03-02T15:44:54.859637', '2023-03-02T15:44:54.859637', '전체보기');
+-- INSERT INTO category(created_At, modified_At, category_name) VALUES ('2023-03-02T15:44:54.859637', '2023-03-02T15:44:54.859637', '없음');


### PR DESCRIPTION
## 구현한 기능
### 1. 블로그 등록 / 수정
- `POST` /blogs/{member-Id} 등록
- `GET` /blogs/edit/{blog-Id} 수정 [데이터 받아오기]
- `PATCH` /blogs/edit/{blog-id} 수정
### 2. 개인 블로그 데이터
- `GET` /blogs/category/{category-id}?page={pages}
- `GET` /blogs/all?nickname={nickname} & page={pages} 전체 게시글 조회

### 3. 블로그 상세 데이터
- `GET` /blogs/{blog-Id} 보기
- `DELETE` /blogs/{blog-Id} 삭제 

### 4. 카테고리
- `POST` /category/{member-id} 생성
- `PATCH` /category/{category-Id} 수정 (*category-id ≥ 2)
- `GET` /category/{member-Id} 멤버별 카테고리 목록 조회 
- `GET` /category 카테고리 전체 목록 조회 
- `DELETE`  /category/{category-Id} 삭제 (*category-id ≥ 2)

## 향후계획
- 추후 좋아요, 대댓글 구현 완료 후 리스폰트 데이터 보강 예정
