### PR TITLE
[Feat] 개인 블로그 데이터 API 구현

### DIFF
--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -48,19 +48,19 @@ public class BlogController {
             return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
         }
 
-        //TODO: Comment 추가예정
         Member foundMember = memberService.findMember(loginMember.getMemberId());
         Category category = categoryService.findSingleCategoryById(blogPostDto.getCategoryId());
         Blog blog = mapper.blogPostDtoToBlog(blogPostDto, category, foundMember);
         blogService.createBlog(blog);
 
+        // blogId 리스폰스 데이터 추가
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("blogId", blog.getBlogId());
-        String jsonStr = gson.toJson(jsonObject);
+        String blogIdToJson
+                = gson.toJson(jsonObject);
 
-        return new ResponseEntity<>(jsonStr, HttpStatus.CREATED);
+        return new ResponseEntity<>(blogIdToJson, HttpStatus.CREATED);
     }
 
     @PatchMapping("/blogs/edit/{blog-id}")
@@ -159,30 +159,6 @@ public class BlogController {
         return new ResponseEntity<>(new ScrollResponseDto<>(isNextPage, blogResponseHomeDto), HttpStatus.OK);
     }
 
-
-//    @GetMapping("/blogs/member/{nickname}")
-//    public ResponseEntity getPersonalBlogData(@PathVariable("nickname") String nickname,
-//                                              @RequestParam(required = false) Long categoryId,
-//                                              @RequestParam(defaultValue = "1", required = false) int page,
-//                                              @RequestParam(defaultValue = "8", required = false) int size) {
-//        log.info("categoryId = {}", categoryId);
-//        Member member = memberService.findMember(nickname);
-//
-//        // categoryId 없으면 멤버가 작성한 모든 블로그 리턴
-//        if (categoryId == null) {
-//            List<Blog> blogs = blogService.findBlogsByMemberNickname(nickname, page, size).getContent();
-//            List<BlogResponseDto.WithCategory> blogResponseHomeDto = mapper.blogListToBlogResponseDtoWithCategory(blogs);
-//
-//            return new ResponseEntity<>(new ListResponseDto<>(blogResponseHomeDto), HttpStatus.OK);
-//        }
-//
-//        // categoryId 있으면 해당 category에 대한 블로그 내역 리턴
-//        List<Blog> blogs = blogService.findBlogsByCategoryId(categoryId, page, size).getContent();
-//        List<BlogResponseDto.WithCategory> blogResponseHomeDto = mapper.blogListToBlogResponseDtoWithCategory(blogs);
-//
-//        return new ResponseEntity<>(new ListResponseDto<>(blogResponseHomeDto), HttpStatus.OK);
-//    }
-
     /* 블로그 상세 데이터 */
     @GetMapping("/blogs/{blog-id}")
     public ResponseEntity<SingleResponseDto<?>> getBlogById(@PathVariable("blog-id") @Positive long blogId) {
@@ -195,7 +171,6 @@ public class BlogController {
         return ResponseEntity.ok(new SingleResponseDto<>(blogResponseDtoWithComment));
     }
 
-
     @GetMapping("/blogs/category/{category-id}")
     public ResponseEntity<?> getBlogsByCategoryName(@PathVariable("category-id") long categoryId,
                                                     @RequestParam(required = false, defaultValue = "1") int page,
@@ -206,7 +181,6 @@ public class BlogController {
 
         return new ResponseEntity<>(new ListResponseDto<>(blogResponseDtoWithCategory), HttpStatus.OK);
     }
-
 
     @GetMapping("/blogs/edit/{blog-id}")
     public ResponseEntity<SingleResponseDto<?>> getBlog(@PathVariable("blog-id") @Positive long blogId) {

--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -137,8 +137,10 @@ public class BlogController {
         log.info("categoryId = {}", categoryId);
         Member member = memberService.findMember(nickname);
 
+        Category singleCategoryById = categoryService.findSingleCategoryById(categoryId);
+
         // categoryId 없으면 멤버가 작성한 모든 블로그 리턴
-        if (categoryId == null) {
+        if (categoryId == null || singleCategoryById.getCategoryName().equals("전체")) {
             Page<Blog> blogsByMemberNickname = blogService.findBlogsByMemberNickname(nickname, page, size);
             return getResponseEntity(page, blogsByMemberNickname);
         }

--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -1,5 +1,8 @@
 package com.server.domain.blog.controller;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 import com.server.domain.blog.dto.BlogDto;
 import com.server.domain.blog.dto.BlogResponseDto;
 import com.server.domain.blog.entity.Blog;
@@ -42,7 +45,7 @@ public class BlogController {
     private final CommentService commentService;
 
     @PostMapping("/blogs")
-    public ResponseEntity<HttpStatus> postBlog(@RequestBody @Valid BlogDto.Post blogPostDto,
+    public ResponseEntity<?> postBlog(@RequestBody @Valid BlogDto.Post blogPostDto,
                                                @AuthenticationPrincipal Member loginMember) {
         if (loginMember == null) {
             log.error("loginMember is null : 허용되지 않은 접근입니다.");
@@ -55,7 +58,13 @@ public class BlogController {
         Blog blog = mapper.blogPostDtoToBlog(blogPostDto, category, foundMember);
         blogService.createBlog(blog);
 
-        return new ResponseEntity<>(HttpStatus.CREATED);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("blogId", blog.getBlogId());
+        String jsonStr = gson.toJson(jsonObject);
+
+        return new ResponseEntity<>(jsonStr,HttpStatus.CREATED);
     }
 
     @PatchMapping("/blogs/edit/{blog-id}")

--- a/server/src/main/java/com/server/domain/blog/service/BlogService.java
+++ b/server/src/main/java/com/server/domain/blog/service/BlogService.java
@@ -135,4 +135,15 @@ public class BlogService {
         }
     }
 
+    public boolean judgeNextPage(int curPage, int totalPage) {
+        if (curPage > totalPage) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_PAGE);
+        }
+
+        if (curPage == totalPage) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/server/src/main/java/com/server/domain/category/dto/CategoryDto.java
+++ b/server/src/main/java/com/server/domain/category/dto/CategoryDto.java
@@ -1,6 +1,8 @@
 package com.server.domain.category.dto;
 
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class CategoryDto {

--- a/server/src/main/java/com/server/exception/ExceptionCode.java
+++ b/server/src/main/java/com/server/exception/ExceptionCode.java
@@ -32,7 +32,10 @@ public enum ExceptionCode {
 
     /* IMAGE */
     IMAGE_FILE_NOT_FONUD(404, "Image file not found"),
-    INVALID_TOKEN(400, "Invalid token");
+    INVALID_TOKEN(400, "Invalid token"),
+
+    /* PAGE */
+    INVALID_PAGE(400, "Invalid page");
 
     @Getter
     private int status;

--- a/server/src/main/java/com/server/response/PageInfo.java
+++ b/server/src/main/java/com/server/response/PageInfo.java
@@ -1,8 +1,8 @@
 package com.server.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
+
+import javax.persistence.Column;
 
 @Getter
 @AllArgsConstructor
@@ -11,4 +11,11 @@ public class PageInfo {
     private int size;
     private long totalElements;
     private int totalPages;
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Judgement{
+        private boolean isFinal = true;
+    }
 }

--- a/server/src/main/java/com/server/response/ScrollResponseDto.java
+++ b/server/src/main/java/com/server/response/ScrollResponseDto.java
@@ -1,0 +1,15 @@
+package com.server.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+
+import javax.persistence.Column;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ScrollResponseDto<T> {
+    private boolean nextPage;
+    private List<T> blogList;
+}


### PR DESCRIPTION
## 구현한 기능
- API 변경사항에 따라 겟요청 재구성 
  - blogData = Category Id를 파라미터로 변경하고 만약에 CategoryId가 없을땐 전체조회할 것, 만약 있다면 해당 카테고리 데이터 조회
  - `GET` /blogs/{nickname}/?categoryId={category-id}&page={pages} 전체 게시글 조회 [ 연월일시분 ]
- 블로그 작성 Post 요청에 Response = blogId 넘겨줄것
- Blog Data = 다음 Page에 불러올수있는 데이터가 있다면 true 없다면 false값 추가
- Blog Data Page Size = 12 -> 8로 변경 
