### PR TITLE
[FIX] MyLikes 페이지네이션 미적용 에러 수정

### DIFF
--- a/server/src/main/java/com/server/domain/blog/controller/BlogController.java
+++ b/server/src/main/java/com/server/domain/blog/controller/BlogController.java
@@ -13,6 +13,9 @@ import com.server.domain.category.service.CategoryService;
 import com.server.domain.comment.dto.CommentResponseDto;
 
 import com.server.domain.comment.service.CommentService;
+import com.server.domain.likes.dto.MyLikeBlogResponseDto;
+import com.server.domain.likes.entity.Likes;
+import com.server.domain.likes.mapper.LikeMapper;
 import com.server.domain.member.entity.Member;
 import com.server.domain.member.service.MemberService;
 import com.server.response.*;
@@ -37,6 +40,7 @@ import java.util.List;
 public class BlogController {
     private final BlogService blogService;
     private final BlogMapper mapper;
+    private final LikeMapper likeMapper;
     private final CategoryService categoryService;
     private final MemberService memberService;
     private final CommentService commentService;
@@ -137,8 +141,13 @@ public class BlogController {
 
         Member member = memberService.findMember(loginMember.getMemberId());
 
-        Page<Blog> blogPage = blogService.findBlogsByMemberWithLike(member, page, size);
-        return getHomeResponseEntity(page, blogPage);
+        Page<Likes> likesPage = blogService.findBlogsByMemberWithLike(member, page, size);
+        boolean isNextPage = blogService.judgeNextPage(page, likesPage);
+
+        List<Likes> likes = likesPage.getContent();
+        List<MyLikeBlogResponseDto> response = likeMapper.likesToMyLikeBlogResponseDtos(likes);
+
+        return new ResponseEntity<>(new ScrollResponseDto<>(isNextPage, response), HttpStatus.OK);
     }
 
     private ResponseEntity getHomeResponseEntity(@RequestParam(defaultValue = "1", required = false) int page, Page<Blog> blogPage) {

--- a/server/src/main/java/com/server/domain/blog/service/BlogService.java
+++ b/server/src/main/java/com/server/domain/blog/service/BlogService.java
@@ -91,19 +91,12 @@ public class BlogService {
         return blogs;
     }
 
-    public Page<Blog> findBlogsByMemberWithLike(Member member, int page, int size) {
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("blogId").descending());
+    public Page<Likes> findBlogsByMemberWithLike(Member member, int page, int size) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("likeId").descending());
 
-        List<Likes> likes = likeRepository.findByMemberAndLikeStatus(member, com.server.domain.likes.entity.Likes.LikeStatus.LIKE);
+        Page<Likes> likes = likeRepository.findByMemberAndLikeStatus(member, Likes.LikeStatus.LIKE, pageable);
 
-        List<Blog> blogList = likes.stream()
-                        .map(like -> blogRepository.findById(like.getBlog().getBlogId()))
-                        .map(Optional::get)
-                        .collect(Collectors.toList());
-
-        Page<Blog> blogs = new PageImpl<>(blogList, pageable, blogList.size());
-
-        return blogs;
+        return likes;
     }
 
     public Page<Blog> findBlogsByMemberNickname(String nickname, int page, int size) {
@@ -140,7 +133,7 @@ public class BlogService {
         }
     }
 
-    public boolean judgeNextPage(int curPage, Page<Blog> blogPage) {
+    public boolean judgeNextPage(int curPage, Page<?> blogPage) {
         int totalPages = blogPage.getTotalPages();
         if (curPage > totalPages) {
             throw new BusinessLogicException(ExceptionCode.INVALID_PAGE);

--- a/server/src/main/java/com/server/domain/likes/dto/MyLikeBlogResponseDto.java
+++ b/server/src/main/java/com/server/domain/likes/dto/MyLikeBlogResponseDto.java
@@ -1,0 +1,22 @@
+package com.server.domain.likes.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MyLikeBlogResponseDto {
+    private Long memberId;
+    private Long blogId;
+    private String titleImageUrl;
+    private String blogTitle;
+    private String blogContent;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 hh시 mm분", timezone = "Asia/Seoul")
+    private LocalDateTime createdAt;
+    private String writer;
+    private int likeCount;
+    private int commentCount;
+}

--- a/server/src/main/java/com/server/domain/likes/mapper/LikeMapper.java
+++ b/server/src/main/java/com/server/domain/likes/mapper/LikeMapper.java
@@ -1,8 +1,12 @@
 package com.server.domain.likes.mapper;
 
+import com.server.domain.blog.entity.Blog;
 import com.server.domain.likes.dto.LikeResponseDto;
+import com.server.domain.likes.dto.MyLikeBlogResponseDto;
 import com.server.domain.likes.entity.Likes;
 import org.mapstruct.Mapper;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface LikeMapper {
@@ -18,4 +22,28 @@ public interface LikeMapper {
 
         return responseDto;
     }
+
+    default MyLikeBlogResponseDto likeToMyLikeBlogResponseDto(Likes likes) {
+        if(likes == null) {
+            return  null;
+        }
+
+        Blog blog = likes.getBlog();
+
+        MyLikeBlogResponseDto response = MyLikeBlogResponseDto.builder()
+                .memberId(blog.getMember().getMemberId())
+                .blogId(blog.getBlogId())
+                .titleImageUrl(blog.getTitleImageUrl())
+                .blogTitle(blog.getBlogTitle())
+                .blogContent(blog.getBlogContent())
+                .createdAt(blog.getCreatedAt())
+                .writer(blog.getMember().getNickName())
+                .likeCount(blog.getLikeCount())
+                .commentCount(blog.getCommentCount())
+                .build();
+
+        return response;
+    }
+
+    List<MyLikeBlogResponseDto> likesToMyLikeBlogResponseDtos(List<Likes> likes);
 }

--- a/server/src/main/java/com/server/domain/likes/repository/LikeRepository.java
+++ b/server/src/main/java/com/server/domain/likes/repository/LikeRepository.java
@@ -3,6 +3,8 @@ package com.server.domain.likes.repository;
 import com.server.domain.blog.entity.Blog;
 import com.server.domain.likes.entity.Likes;
 import com.server.domain.member.entity.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -11,5 +13,5 @@ import java.util.Optional;
 public interface LikeRepository extends JpaRepository<Likes, Long> {
     Optional<Likes> findByMemberAndBlog(Member member, Blog blog);
     void deleteByMemberAndBlog(Member member, Blog blog);
-    List<Likes> findByMemberAndLikeStatus(Member member, Likes.LikeStatus likeStatus);
+    Page<Likes> findByMemberAndLikeStatus(Member member, Likes.LikeStatus likeStatus, Pageable pageable);
 }


### PR DESCRIPTION
### 원인
기존에는 List<Like\>를 가지고 List<Blog\>를 추출한 후에 Pagenation을 적용하였습니다.
` Page<Blog\> blogs = new PageImpl<>(blogList, pageable, blogList.size());`
List와 pageable로 `PageImpl`의 인스턴스를 생성할 때, List의 사이즈는 pageable의 작성된 size와 같거나 작다고 가정 되기 때문에 List의 사이즈가 더 크다면, pagenation이 제대로 처리되지 않는 일이 발생한다고 하네요!!

### 수정한 내용
- Page<Like\>로 추출해서 mapper를 사용해 BlogList를 responseDto를 만들었습니다~